### PR TITLE
Update registry-cache to v0.15.0 and split admission charts

### DIFF
--- a/chart-releaser-config.yaml
+++ b/chart-releaser-config.yaml
@@ -225,9 +225,21 @@ sources:
 
   - name: "registry-cache"
     repo: "gardener/gardener-extension-registry-cache"
-    version: "v0.13.0"
+    version: "v0.15.0"
     charts:
       - "controller-registration"
+
+  - name: "admission-registry-cache-application"
+    repo: "gardener/gardener-extension-registry-cache"
+    version: "v0.15.0"
+    charts:
+      - "charts/admission/charts/application"
+
+  - name: "admission-registry-cache-runtime"
+    repo: "gardener/gardener-extension-registry-cache"
+    version: "v0.15.0"
+    charts:
+      - "charts/admission/charts/runtime"
 
   - name: "gardener-webterminal"
     version: "v0.34.0"


### PR DESCRIPTION
The newest release of registry-cache chart requires to be split: https://github.com/gardener/gardener-extension-registry-cache/releases/tag/v0.15.0