### PR TITLE
Fix image-rewriter chart

### DIFF
--- a/chart-releaser-config.yaml
+++ b/chart-releaser-config.yaml
@@ -325,3 +325,9 @@ sources:
     version: "v1.6.0"
     charts:
       - "charts/seed"
+  
+  - name: "image-rewriter"
+    repo: "gardener/gardener-extension-image-rewriter"
+    version: "v0.5.0"
+    charts:
+      - "charts/gardener-extension-image-rewriter"

--- a/chart-releaser-config.yaml
+++ b/chart-releaser-config.yaml
@@ -330,4 +330,4 @@ sources:
     repo: "gardener/gardener-extension-image-rewriter"
     version: "v0.5.0"
     charts:
-      - "charts/gardener-extension-image-rewriter"
+      - "controller-registration"


### PR DESCRIPTION
Switch from using the chart directory to controller-registration.

I initially based this ion the `acl` extension, but the `shoot-flux` extension turned out to be a closer reference for the `image-rewriter`.

I’m not entirely sure whether this change automatically generates a `controller-registration.yaml` containing the base64-encoded chart. Please let me know if this assumption is incorrect.